### PR TITLE
(Jackson Serialize) Writing to string should use the `ObjectMapper` not `toString()`.

### DIFF
--- a/serializer-jackson/src/main/java/org/ccci/gto/globalreg/serializer/jackson/JacksonSerializer.java
+++ b/serializer-jackson/src/main/java/org/ccci/gto/globalreg/serializer/jackson/JacksonSerializer.java
@@ -56,8 +56,7 @@ public class JacksonSerializer extends JsonIntermediateSerializer<JsonNode, Json
 		catch(IOException exception)
 		{
 			LOG.error("Error writing JsonNode to String", exception);
-			Throwables.propagate(exception);
-			return null; // unreachable
+			throw Throwables.propagate(exception);
 		}
     }
 


### PR DESCRIPTION
- Though it's not clear from looking at the source code, it appears that toString does not honor JAXB or Jackson2 annotations as defined in the jackson spec.
