### PR TITLE
AEM-716 - Remove Guava dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,10 +13,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>

--- a/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
@@ -1,6 +1,5 @@
 package org.ccci.gto.globalreg;
 
-import com.google.common.base.Joiner;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import org.ccci.gto.globalreg.serializer.Serializer;
@@ -16,7 +15,6 @@ import java.util.Set;
 
 public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryClient {
     private static final MediaType APPLICATION_JSON = MediaType.create("application", "json");
-    private static final Joiner COMMA_JOINER = Joiner.on(",");
     private static final String TRUE = "true";
 
     protected String apiUrl;
@@ -154,7 +152,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
 
     private void addFieldsParameterIfNecessary(final Request request, final Set<String> fields) {
         if (fields != null) {
-            request.queryParams.put(PARAM_FIELDS, List.of(COMMA_JOINER.join(fields)));
+            request.queryParams.put(PARAM_FIELDS, List.of(String.join(",", fields)));
         }
     }
 

--- a/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
@@ -1,7 +1,5 @@
 package org.ccci.gto.globalreg;
 
-import com.google.common.net.HttpHeaders;
-import com.google.common.net.MediaType;
 import org.ccci.gto.globalreg.serializer.Serializer;
 
 import javax.annotation.Nonnull;
@@ -14,7 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 
 public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryClient {
-    private static final MediaType APPLICATION_JSON = MediaType.create("application", "json");
+    private static final String APPLICATION_JSON = "application/json";
     private static final String TRUE = "true";
 
     protected String apiUrl;
@@ -114,7 +112,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         final Request request = new Request();
         request.method = "POST";
         request.path = new String[]{PATH_ENTITIES};
-        request.contentType = APPLICATION_JSON.toString();
+        request.contentType = APPLICATION_JSON;
         request.content = this.serializer.serializeEntity(type, entity);
         addFullResponseParameterIfNecessary(request);
         addFieldsParameterIfNecessary(request, fields);
@@ -136,7 +134,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         final Request request = new Request();
         request.method = "PUT";
         request.path = new String[]{PATH_ENTITIES, id};
-        request.contentType = APPLICATION_JSON.toString();
+        request.contentType = APPLICATION_JSON;
         request.content = this.serializer.serializeEntity(type, entity);
         addFullResponseParameterIfNecessary(request);
         addFieldsParameterIfNecessary(request, fields);
@@ -204,7 +202,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         final Request request = new Request();
         request.method = "POST";
         request.path = new String[]{PATH_ENTITY_TYPES};
-        request.contentType = APPLICATION_JSON.toString();
+        request.contentType = APPLICATION_JSON;
         request.content = this.serializer.serializeEntityType(type);
 
         // execute request
@@ -304,7 +302,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         public String content = null;
 
         Request() {
-            this.headers.put(HttpHeaders.ACCEPT, APPLICATION_JSON.toString());
+            this.headers.put("Accept", APPLICATION_JSON);
         }
     }
 

--- a/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
@@ -1,7 +1,6 @@
 package org.ccci.gto.globalreg;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import org.ccci.gto.globalreg.serializer.Serializer;
@@ -12,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryClient {
@@ -317,7 +317,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
 
         public Response(final int code, @Nullable final String content) {
             this.code = code;
-            this.content = Strings.nullToEmpty(content);
+            this.content = Objects.toString(content, "");
         }
     }
 

--- a/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClient.java
@@ -2,15 +2,13 @@ package org.ccci.gto.globalreg;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import org.ccci.gto.globalreg.serializer.Serializer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +64,8 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
                 }
 
                 // append all values for this filter
-                request.queryParams.putAll(name.toString(), Lists.newArrayList(filter.getValues()));
+                request.queryParams.computeIfAbsent(name.toString(), k -> new ArrayList<>())
+                    .addAll(List.of(filter.getValues()));
             }
         }
     }
@@ -96,9 +95,9 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         // build request
         final Request request = new Request();
         request.path = new String[]{PATH_ENTITIES};
-        request.queryParams.put(PARAM_ENTITY_TYPE, type.getEntityType());
-        request.queryParams.put(PARAM_PAGE, Integer.toString(page));
-        request.queryParams.put(PARAM_PER_PAGE, Integer.toString(perPage));
+        request.queryParams.put(PARAM_ENTITY_TYPE, List.of(type.getEntityType()));
+        request.queryParams.put(PARAM_PAGE, List.of(Integer.toString(page)));
+        request.queryParams.put(PARAM_PER_PAGE, List.of(Integer.toString(perPage)));
         this.attachFilters(request, filters);
         addFieldsParameterIfNecessary(request, fields);
 
@@ -155,19 +154,19 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
 
     private void addFieldsParameterIfNecessary(final Request request, final Set<String> fields) {
         if (fields != null) {
-            request.queryParams.put(PARAM_FIELDS, COMMA_JOINER.join(fields));
+            request.queryParams.put(PARAM_FIELDS, List.of(COMMA_JOINER.join(fields)));
         }
     }
 
     private void addFullResponseParameterIfNecessary(final Request request) {
         if (fullResponsesFromUpdates) {
-            request.queryParams.put(PARAM_FULL_RESPONSE, TRUE);
+            request.queryParams.put(PARAM_FULL_RESPONSE, List.of(TRUE));
         }
     }
 
     private void addRequireMdmParameterIfNecessary(final Request request, final boolean requireMdm) {
         if (requireMdm) {
-            request.queryParams.put(PARAM_REQUIRE_MDM, TRUE);
+            request.queryParams.put(PARAM_REQUIRE_MDM, List.of(TRUE));
         }
     }
 
@@ -189,7 +188,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         // build request
         final Request request = new Request();
         request.path = new String[]{PATH_ENTITY_TYPES};
-        request.queryParams.put(PARAM_PAGE, Integer.toString(page));
+        request.queryParams.put(PARAM_PAGE, List.of(Integer.toString(page)));
         this.attachFilters(request, filters);
 
         // execute request
@@ -254,7 +253,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         // build request
         final Request request = new Request();
         request.path = new String[]{PATH_MEASUREMENT_TYPES};
-        request.queryParams.put(PARAM_PAGE, Integer.toString(page));
+        request.queryParams.put(PARAM_PAGE, List.of(Integer.toString(page)));
         this.attachFilters(request, filters);
 
         // execute request
@@ -302,7 +301,7 @@ public abstract class BaseGlobalRegistryClient extends AbstractGlobalRegistryCli
         public String method = "GET";
         public String[] path = new String[0];
         public final Map<String, String> headers = new HashMap<>();
-        public final Multimap<String, String> queryParams = HashMultimap.create();
+        public final Map<String, List<String>> queryParams = new HashMap<>();
         public String contentType = null;
         public String content = null;
 

--- a/api/src/main/java/org/ccci/gto/globalreg/ClientErrorException.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/ClientErrorException.java
@@ -1,8 +1,5 @@
 package org.ccci.gto.globalreg;
 
-import com.google.common.base.Ascii;
-import com.google.common.base.Preconditions;
-
 /**
  * A {@code HttpErrorException} that indicates a client-side global registry error.
  * The response status code is in the 4xx range.
@@ -17,7 +14,9 @@ public class ClientErrorException extends HttpErrorException {
     }
 
     private static int checkStatus(final int statusCode) {
-        Preconditions.checkArgument(statusCode / 100 == 4);
+        if (statusCode / 100 != 4) {
+            throw new IllegalArgumentException("Status code must be in 4xx range, got: " + statusCode);
+        }
         return statusCode;
     }
 

--- a/api/src/main/java/org/ccci/gto/globalreg/HttpErrorException.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/HttpErrorException.java
@@ -1,8 +1,6 @@
 package org.ccci.gto.globalreg;
 
 import com.google.common.base.Ascii;
-import com.google.common.base.Preconditions;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,7 +37,9 @@ public class HttpErrorException extends GlobalRegistryException {
     }
 
     private static int checkStatus(final int statusCode) {
-        Preconditions.checkArgument(statusCode / 100 != 2);
+        if (statusCode / 100 == 2) {
+            throw new IllegalArgumentException("Status code must not be in the 2xx range");
+        }
         return statusCode;
     }
 

--- a/api/src/main/java/org/ccci/gto/globalreg/HttpErrorException.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/HttpErrorException.java
@@ -1,6 +1,5 @@
 package org.ccci.gto.globalreg;
 
-import com.google.common.base.Ascii;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,8 +48,15 @@ public class HttpErrorException extends GlobalRegistryException {
             return String.format("status code %s: %s", statusCode, error);
         } else {
             // most likely an html response
-            return String.format("status code %s: %n%s", statusCode, Ascii.truncate(responseContent, 200, "…"));
+            return String.format("status code %s: %n%s", statusCode, truncate(responseContent, 200));
         }
+    }
+
+    private static String truncate(String str, int maxLength) {
+        if (str == null || str.length() <= maxLength) {
+            return str;
+        }
+        return str.substring(0, maxLength) + "…";
     }
 
     private static String getJsonErrorMessageIfPossible(final String responseContent) {

--- a/api/src/main/java/org/ccci/gto/globalreg/ResponseList.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/ResponseList.java
@@ -1,11 +1,17 @@
 package org.ccci.gto.globalreg;
 
-import com.google.common.collect.ForwardingList;
-
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
-public class ResponseList<T> extends ForwardingList<T> {
+public class ResponseList<T> implements List<T> {
     private Meta meta = new Meta();
     private final List<T> results = new ArrayList<>();
 
@@ -21,9 +27,169 @@ public class ResponseList<T> extends ForwardingList<T> {
         return this.meta != null && (this.meta.hasMore || this.meta.totalPages > this.meta.page);
     }
 
-    @Override
     protected List<T> delegate() {
         return this.results;
+    }
+
+    // List implementation methods
+    @Override
+    public int size() {
+        return results.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return results.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return results.contains(o);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return results.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return results.toArray();
+    }
+
+    @Override
+    public <T1> T1[] toArray(T1[] a) {
+        return results.toArray(a);
+    }
+
+    @Override
+    public boolean add(T t) {
+        return results.add(t);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return results.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return results.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        return results.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends T> c) {
+        return results.addAll(index, c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return results.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return results.retainAll(c);
+    }
+
+    @Override
+    public void replaceAll(UnaryOperator<T> operator) {
+        results.replaceAll(operator);
+    }
+
+    @Override
+    public void sort(java.util.Comparator<? super T> c) {
+        results.sort(c);
+    }
+
+    @Override
+    public void clear() {
+        results.clear();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return results.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return results.hashCode();
+    }
+
+    @Override
+    public T get(int index) {
+        return results.get(index);
+    }
+
+    @Override
+    public T set(int index, T element) {
+        return results.set(index, element);
+    }
+
+    @Override
+    public void add(int index, T element) {
+        results.add(index, element);
+    }
+
+    @Override
+    public T remove(int index) {
+        return results.remove(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return results.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return results.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<T> listIterator() {
+        return results.listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(int index) {
+        return results.listIterator(index);
+    }
+
+    @Override
+    public List<T> subList(int fromIndex, int toIndex) {
+        return results.subList(fromIndex, toIndex);
+    }
+
+    @Override
+    public Spliterator<T> spliterator() {
+        return results.spliterator();
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super T> filter) {
+        return results.removeIf(filter);
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return results.stream();
+    }
+
+    @Override
+    public Stream<T> parallelStream() {
+        return results.parallelStream();
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> action) {
+        results.forEach(action);
     }
 
     public static final class Meta {

--- a/api/src/main/java/org/ccci/gto/globalreg/ServerErrorException.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/ServerErrorException.java
@@ -1,7 +1,5 @@
 package org.ccci.gto.globalreg;
 
-import com.google.common.base.Preconditions;
-
 /**
  * A {@code HttpErrorException} that indicates a server-side global registry error.
  * The response status code is in the 5xx range.
@@ -16,7 +14,9 @@ public class ServerErrorException extends HttpErrorException {
     }
 
     private static int checkStatus(final int statusCode) {
-        Preconditions.checkArgument(statusCode / 100 == 5);
+        if (statusCode / 100 != 5) {
+            throw new IllegalArgumentException("Status code must be in 5xx range, got: " + statusCode);
+        }
         return statusCode;
     }
 

--- a/api/src/main/java/org/ccci/gto/globalreg/serializer/JsonIntermediateSerializer.java
+++ b/api/src/main/java/org/ccci/gto/globalreg/serializer/JsonIntermediateSerializer.java
@@ -1,6 +1,5 @@
 package org.ccci.gto.globalreg.serializer;
 
-import com.google.common.primitives.Ints;
 import org.ccci.gto.globalreg.*;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -321,7 +320,13 @@ public abstract class JsonIntermediateSerializer<O, A> extends AbstractSerialize
 
         protected Integer getInt(final String key, final Integer def) {
             final Long val = this.getLong(key, null);
-            return val != null ? Ints.checkedCast(val) : def;
+            if (val != null) {
+                if (val < Integer.MIN_VALUE || val > Integer.MAX_VALUE) {
+                    throw new IllegalArgumentException("Value " + val + " is out of range for int");
+                }
+                return val.intValue();
+            }
+            return def;
         }
 
         protected Long getLong(final String key) {

--- a/api/src/test/java/org/ccci/gto/globalreg/serializer/AbstractSerializerTest.java
+++ b/api/src/test/java/org/ccci/gto/globalreg/serializer/AbstractSerializerTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Closer;
 import com.jayway.restassured.path.json.JsonPath;

--- a/api/src/test/java/org/ccci/gto/globalreg/serializer/AbstractSerializerTest.java
+++ b/api/src/test/java/org/ccci/gto/globalreg/serializer/AbstractSerializerTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.io.CharStreams;
-import com.google.common.io.Closer;
 import com.jayway.restassured.path.json.JsonPath;
 import org.ccci.gto.globalreg.*;
 import org.joda.time.DateTime;
@@ -16,6 +14,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -29,7 +28,9 @@ public abstract class AbstractSerializerTest {
     private String loadResource(final String name) throws IOException {
         try (final InputStreamReader in = new InputStreamReader(AbstractSerializerTest.class.getResourceAsStream
                 (name), StandardCharsets.UTF_8)) {
-            return CharStreams.toString(in);
+            StringWriter writer = new StringWriter();
+            in.transferTo(writer);
+            return writer.toString();
         }
     }
 

--- a/client-testing/pom.xml
+++ b/client-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-testing</artifactId>

--- a/client-testing/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClientIT.java
+++ b/client-testing/src/main/java/org/ccci/gto/globalreg/BaseGlobalRegistryClientIT.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
 
-import com.google.common.collect.ImmutableSet;
 import org.ccci.gto.globalreg.serializer.json.JSONObjectType;
 import org.ccci.gto.globalreg.serializer.json.JsonSerializer;
 import org.json.JSONObject;
@@ -21,6 +20,7 @@ import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 public abstract class BaseGlobalRegistryClientIT {
 
@@ -113,7 +113,7 @@ public abstract class BaseGlobalRegistryClientIT {
         tmp.put("first_name", "Updated Name");
         tmp.put("last_name", "Last");
         final JSONObject updatedEntity = client.updateEntity(TYPE_PERSON, newEntity.getString("id"), tmp,
-                ImmutableSet.of("first_name", "last_name"), true);
+                Set.of("first_name", "last_name"), true);
 
         assertNotNull(updatedEntity);
         assertEquals("Updated Name", updatedEntity.getString("first_name"));

--- a/entities/jackson/pom.xml
+++ b/entities/jackson/pom.xml
@@ -17,10 +17,5 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/entities/jackson/pom.xml
+++ b/entities/jackson/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Address.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Address.java
@@ -1,7 +1,7 @@
 
 package org.ccci.gto.globalreg.entity.jackson;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Address.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Address.java
@@ -49,13 +49,13 @@ public class Address {
 
     /**
      * No args constructor for use in serialization
-     * 
+     *
      */
     public Address() {
     }
 
     /**
-     * 
+     *
      * @param clientIntegrationId
      * @param country
      * @param city
@@ -83,7 +83,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The id
      */
@@ -93,7 +93,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param id
      *     The id
      */
@@ -103,7 +103,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The active
      */
@@ -113,7 +113,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param active
      *     The active
      */
@@ -123,7 +123,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The addressType
      */
@@ -133,7 +133,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param addressType
      *     The address_type
      */
@@ -143,7 +143,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The startDate
      */
@@ -153,7 +153,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param startDate
      *     The start_date
      */
@@ -163,7 +163,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The line1
      */
@@ -173,7 +173,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param line1
      *     The line1
      */
@@ -183,7 +183,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The city
      */
@@ -193,7 +193,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param city
      *     The city
      */
@@ -203,7 +203,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The state
      */
@@ -213,7 +213,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param state
      *     The state
      */
@@ -223,7 +223,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The postalCode
      */
@@ -233,7 +233,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param postalCode
      *     The postal_code
      */
@@ -243,7 +243,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The country
      */
@@ -253,7 +253,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param country
      *     The country
      */
@@ -263,7 +263,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The parentId
      */
@@ -273,7 +273,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param parentId
      *     The parent_id
      */
@@ -283,7 +283,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @return
      *     The clientIntegrationId
      */
@@ -293,7 +293,7 @@ public class Address {
     }
 
     /**
-     * 
+     *
      * @param clientIntegrationId
      *     The client_integration_id
      */

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Address.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Address.java
@@ -5,8 +5,7 @@ import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
@@ -305,41 +304,41 @@ public class Address {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("id", id)
-                .add("active", active)
-                .add("addressType", addressType)
-                .add("startDate", startDate)
-                .add("line1", line1)
-                .add("city", city)
-                .add("state", state)
-                .add("postalCode", postalCode)
-                .add("country", country)
-                .add("parentId", parentId)
-                .add("clientIntegrationId", clientIntegrationId)
-                .toString();
+        return new StringBuilder("Address{")
+            .append("id='").append(id).append('\'')
+            .append(", active=").append(active)
+            .append(", addressType='").append(addressType).append('\'')
+            .append(", startDate='").append(startDate).append('\'')
+            .append(", line1='").append(line1).append('\'')
+            .append(", city='").append(city).append('\'')
+            .append(", state='").append(state).append('\'')
+            .append(", postalCode='").append(postalCode).append('\'')
+            .append(", country='").append(country).append('\'')
+            .append(", parentId='").append(parentId).append('\'')
+            .append(", clientIntegrationId='").append(clientIntegrationId).append('\'')
+            .append('}').toString();
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Address)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         Address address = (Address) o;
-        return Objects.equal(id, address.id) &&
-                Objects.equal(active, address.active) &&
-                Objects.equal(addressType, address.addressType) &&
-                Objects.equal(startDate, address.startDate) &&
-                Objects.equal(line1, address.line1) &&
-                Objects.equal(city, address.city) &&
-                Objects.equal(state, address.state) &&
-                Objects.equal(postalCode, address.postalCode) &&
-                Objects.equal(country, address.country) &&
-                Objects.equal(parentId, address.parentId) &&
-                Objects.equal(clientIntegrationId, address.clientIntegrationId);
+        return Objects.equals(id, address.id) &&
+                Objects.equals(active, address.active) &&
+                Objects.equals(addressType, address.addressType) &&
+                Objects.equals(startDate, address.startDate) &&
+                Objects.equals(line1, address.line1) &&
+                Objects.equals(city, address.city) &&
+                Objects.equals(state, address.state) &&
+                Objects.equals(postalCode, address.postalCode) &&
+                Objects.equals(country, address.country) &&
+                Objects.equals(parentId, address.parentId) &&
+                Objects.equals(clientIntegrationId, address.clientIntegrationId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id, active, addressType, startDate, line1, city, state, postalCode, country, parentId, clientIntegrationId);
+        return Objects.hash(id, active, addressType, startDate, line1, city, state, postalCode, country, parentId, clientIntegrationId);
     }
 }

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Authentication.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Authentication.java
@@ -31,13 +31,13 @@ public class Authentication {
 
     /**
      * No args constructor for use in serialization
-     * 
+     *
      */
     public Authentication() {
     }
 
     /**
-     * 
+     *
      * @param keyGuid
      * @param relayGuid
      * @param id
@@ -53,7 +53,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @return
      *     The id
      */
@@ -63,7 +63,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @param id
      *     The id
      */
@@ -73,7 +73,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @return
      *     The relayGuid
      */
@@ -83,7 +83,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @param relayGuid
      *     The relay_guid
      */
@@ -93,7 +93,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @return
      *     The keyGuid
      */
@@ -103,7 +103,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @param keyGuid
      *     The key_guid
      */
@@ -113,7 +113,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @return
      *     The parentId
      */
@@ -123,7 +123,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @param parentId
      *     The parent_id
      */
@@ -133,7 +133,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @return
      *     The clientUpdatedAt
      */
@@ -143,7 +143,7 @@ public class Authentication {
     }
 
     /**
-     * 
+     *
      * @param clientUpdatedAt
      *     The client_updated_at
      */

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Authentication.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Authentication.java
@@ -5,8 +5,7 @@ import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
@@ -155,29 +154,29 @@ public class Authentication {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("id", id)
-                .add("relayGuid", relayGuid)
-                .add("keyGuid", keyGuid)
-                .add("parentId", parentId)
-                .add("clientUpdatedAt", clientUpdatedAt)
-                .toString();
+        return new StringBuilder("Authentication{")
+            .append("id='").append(id).append('\'')
+            .append(", relayGuid='").append(relayGuid).append('\'')
+            .append(", keyGuid='").append(keyGuid).append('\'')
+            .append(", parentId='").append(parentId).append('\'')
+            .append(", clientUpdatedAt='").append(clientUpdatedAt).append('\'')
+            .append('}').toString();
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Authentication)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         Authentication that = (Authentication) o;
-        return Objects.equal(id, that.id) &&
-                Objects.equal(relayGuid, that.relayGuid) &&
-                Objects.equal(keyGuid, that.keyGuid) &&
-                Objects.equal(parentId, that.parentId) &&
-                Objects.equal(clientUpdatedAt, that.clientUpdatedAt);
+        return Objects.equals(id, that.id) &&
+                Objects.equals(relayGuid, that.relayGuid) &&
+                Objects.equals(keyGuid, that.keyGuid) &&
+                Objects.equals(parentId, that.parentId) &&
+                Objects.equals(clientUpdatedAt, that.clientUpdatedAt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id, relayGuid, keyGuid, parentId, clientUpdatedAt);
+        return Objects.hash(id, relayGuid, keyGuid, parentId, clientUpdatedAt);
     }
 }

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Authentication.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Authentication.java
@@ -1,7 +1,7 @@
 
 package org.ccci.gto.globalreg.entity.jackson;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/EmailAddress.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/EmailAddress.java
@@ -31,13 +31,13 @@ public class EmailAddress {
 
     /**
      * No args constructor for use in serialization
-     * 
+     *
      */
     public EmailAddress() {
     }
 
     /**
-     * 
+     *
      * @param clientIntegrationId
      * @param id
      * @param clientUpdatedAt
@@ -53,7 +53,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @return
      *     The id
      */
@@ -63,7 +63,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @param id
      *     The id
      */
@@ -73,7 +73,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @return
      *     The email
      */
@@ -83,7 +83,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @param email
      *     The email
      */
@@ -93,7 +93,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @return
      *     The parentId
      */
@@ -103,7 +103,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @param parentId
      *     The parent_id
      */
@@ -113,7 +113,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @return
      *     The clientIntegrationId
      */
@@ -123,7 +123,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @param clientIntegrationId
      *     The client_integration_id
      */
@@ -133,7 +133,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @return
      *     The clientUpdatedAt
      */
@@ -143,7 +143,7 @@ public class EmailAddress {
     }
 
     /**
-     * 
+     *
      * @param clientUpdatedAt
      *     The client_updated_at
      */

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/EmailAddress.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/EmailAddress.java
@@ -1,7 +1,7 @@
 
 package org.ccci.gto.globalreg.entity.jackson;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/EmailAddress.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/EmailAddress.java
@@ -5,8 +5,7 @@ import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
@@ -155,29 +154,29 @@ public class EmailAddress {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("id", id)
-                .add("email", email)
-                .add("parentId", parentId)
-                .add("clientIntegrationId", clientIntegrationId)
-                .add("clientUpdatedAt", clientUpdatedAt)
-                .toString();
+        return new StringBuilder("EmailAddress{")
+            .append("id='").append(id).append('\'')
+            .append(", email='").append(email).append('\'')
+            .append(", parentId='").append(parentId).append('\'')
+            .append(", clientIntegrationId='").append(clientIntegrationId).append('\'')
+            .append(", clientUpdatedAt='").append(clientUpdatedAt).append('\'')
+            .append('}').toString();
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof EmailAddress)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         EmailAddress that = (EmailAddress) o;
-        return Objects.equal(id, that.id) &&
-                Objects.equal(email, that.email) &&
-                Objects.equal(parentId, that.parentId) &&
-                Objects.equal(clientIntegrationId, that.clientIntegrationId) &&
-                Objects.equal(clientUpdatedAt, that.clientUpdatedAt);
+        return Objects.equals(id, that.id) &&
+                Objects.equals(email, that.email) &&
+                Objects.equals(parentId, that.parentId) &&
+                Objects.equals(clientIntegrationId, that.clientIntegrationId) &&
+                Objects.equals(clientUpdatedAt, that.clientUpdatedAt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id, email, parentId, clientIntegrationId, clientUpdatedAt);
+        return Objects.hash(id, email, parentId, clientIntegrationId, clientUpdatedAt);
     }
 }

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Person.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Person.java
@@ -151,13 +151,13 @@ public class Person {
 
     /**
      * No args constructor for use in serialization
-     * 
+     *
      */
     public Person() {
     }
 
     /**
-     * 
+     *
      * @param originalHireDate
      * @param supervisorEmplid
      * @param lastName
@@ -253,7 +253,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The id
      */
@@ -263,7 +263,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param id
      *     The id
      */
@@ -273,7 +273,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The accountNumber
      */
@@ -283,7 +283,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param accountNumber
      *     The account_number
      */
@@ -293,7 +293,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The activeStatus
      */
@@ -303,7 +303,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param activeStatus
      *     The active_status
      */
@@ -313,7 +313,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The birthDay
      */
@@ -323,7 +323,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param birthDay
      *     The birth_day
      */
@@ -333,7 +333,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The birthMonth
      */
@@ -343,7 +343,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param birthMonth
      *     The birth_month
      */
@@ -353,7 +353,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The cruEmployee
      */
@@ -363,7 +363,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param cruEmployee
      *     The cru_employee
      */
@@ -373,7 +373,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The dateJoinedStaff
      */
@@ -383,7 +383,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param dateJoinedStaff
      *     The date_joined_staff
      */
@@ -393,7 +393,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The firstName
      */
@@ -403,7 +403,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param firstName
      *     The first_name
      */
@@ -413,7 +413,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The fundingSource
      */
@@ -423,7 +423,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param fundingSource
      *     The funding_source
      */
@@ -433,7 +433,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The gender
      */
@@ -443,7 +443,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param gender
      *     The gender
      */
@@ -453,7 +453,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The hrStatusCode
      */
@@ -463,7 +463,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param hrStatusCode
      *     The hr_status_code
      */
@@ -473,7 +473,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The isStaff
      */
@@ -483,7 +483,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param isStaff
      *     The is_staff
      */
@@ -493,7 +493,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The lakeHartMailCode
      */
@@ -503,7 +503,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param lakeHartMailCode
      *     The lake_hart_mail_code
      */
@@ -513,7 +513,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The lastName
      */
@@ -523,7 +523,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param lastName
      *     The last_name
      */
@@ -533,7 +533,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The locationCode
      */
@@ -543,7 +543,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param locationCode
      *     The location_code
      */
@@ -553,7 +553,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The locationWork
      */
@@ -563,7 +563,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param locationWork
      *     The location_work
      */
@@ -573,7 +573,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The maritalStatus
      */
@@ -583,7 +583,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param maritalStatus
      *     The marital_status
      */
@@ -593,7 +593,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The middleName
      */
@@ -603,7 +603,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param middleName
      *     The middle_name
      */
@@ -613,7 +613,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The nameAddressEditFlag
      */
@@ -623,7 +623,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param nameAddressEditFlag
      *     The name_address_edit_flag
      */
@@ -633,7 +633,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The originalHireDate
      */
@@ -643,7 +643,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param originalHireDate
      *     The original_hire_date
      */
@@ -653,7 +653,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The paygroup
      */
@@ -663,7 +663,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param paygroup
      *     The paygroup
      */
@@ -673,7 +673,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The preferredName
      */
@@ -683,7 +683,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param preferredName
      *     The preferred_name
      */
@@ -693,7 +693,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The ministryCode
      */
@@ -703,7 +703,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param ministryCode
      *     The ministry_code
      */
@@ -713,7 +713,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The ministryDescr
      */
@@ -723,7 +723,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param ministryDescr
      *     The ministry_descr
      */
@@ -733,7 +733,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The suffix
      */
@@ -743,7 +743,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param suffix
      *     The suffix
      */
@@ -753,7 +753,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The title
      */
@@ -763,7 +763,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param title
      *     The title
      */
@@ -773,7 +773,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The subMinistryCode
      */
@@ -783,7 +783,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param subMinistryCode
      *     The sub_ministry_code
      */
@@ -793,7 +793,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The subMinistryDescr
      */
@@ -803,7 +803,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param subMinistryDescr
      *     The sub_ministry_descr
      */
@@ -813,7 +813,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The emailAddress
      */
@@ -823,7 +823,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param emailAddress
      *     The email_address
      */
@@ -833,7 +833,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The phoneNumber
      */
@@ -843,7 +843,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param phoneNumber
      *     The phone_number
      */
@@ -853,7 +853,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The authentication
      */
@@ -863,7 +863,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param authentication
      *     The authentication
      */
@@ -873,7 +873,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The address
      */
@@ -883,7 +883,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param address
      *     The address
      */
@@ -893,7 +893,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The birthYear
      */
@@ -903,7 +903,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param birthYear
      *     The birth_year
      */
@@ -913,7 +913,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The birthDate
      */
@@ -923,7 +923,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param birthDate
      *     The birth_date
      */
@@ -933,7 +933,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The countryOfResidence
      */
@@ -943,7 +943,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param countryOfResidence
      *     The country_of_residence
      */
@@ -953,7 +953,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The employmentCountry
      */
@@ -963,7 +963,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param employmentCountry
      *     The employment_country
      */
@@ -973,7 +973,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The language
      */
@@ -983,7 +983,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param language
      *     The language
      */
@@ -993,7 +993,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The jobStatus
      */
@@ -1003,7 +1003,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param jobStatus
      *     The job_status
      */
@@ -1013,7 +1013,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The deptCode
      */
@@ -1023,7 +1023,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param deptCode
      *     The dept_code
      */
@@ -1033,7 +1033,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The deptDescr
      */
@@ -1043,7 +1043,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param deptDescr
      *     The dept_descr
      */
@@ -1053,7 +1053,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The jobCode
      */
@@ -1063,7 +1063,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param jobCode
      *     The job_code
      */
@@ -1073,7 +1073,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The jobDescr
      */
@@ -1083,7 +1083,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param jobDescr
      *     The job_descr
      */
@@ -1093,7 +1093,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The supervisorEmplid
      */
@@ -1103,7 +1103,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param supervisorEmplid
      *     The supervisor_emplid
      */
@@ -1113,7 +1113,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The clientUpdatedAt
      */
@@ -1123,7 +1123,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param clientUpdatedAt
      *     The client_updated_at
      */
@@ -1133,7 +1133,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @return
      *     The clientIntegrationId
      */
@@ -1143,7 +1143,7 @@ public class Person {
     }
 
     /**
-     * 
+     *
      * @param clientIntegrationId
      *     The client_integration_id
      */

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Person.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Person.java
@@ -1,7 +1,7 @@
 
 package org.ccci.gto.globalreg.entity.jackson;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Person.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/Person.java
@@ -5,8 +5,7 @@ import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
@@ -1155,109 +1154,109 @@ public class Person {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("id", id)
-                .add("accountNumber", accountNumber)
-                .add("activeStatus", activeStatus)
-                .add("birthDay", birthDay)
-                .add("birthMonth", birthMonth)
-                .add("cruEmployee", cruEmployee)
-                .add("dateJoinedStaff", dateJoinedStaff)
-                .add("firstName", firstName)
-                .add("fundingSource", fundingSource)
-                .add("gender", gender)
-                .add("hrStatusCode", hrStatusCode)
-                .add("isStaff", isStaff)
-                .add("lakeHartMailCode", lakeHartMailCode)
-                .add("lastName", lastName)
-                .add("locationCode", locationCode)
-                .add("locationWork", locationWork)
-                .add("maritalStatus", maritalStatus)
-                .add("middleName", middleName)
-                .add("nameAddressEditFlag", nameAddressEditFlag)
-                .add("originalHireDate", originalHireDate)
-                .add("paygroup", paygroup)
-                .add("preferredName", preferredName)
-                .add("ministryCode", ministryCode)
-                .add("ministryDescr", ministryDescr)
-                .add("suffix", suffix)
-                .add("title", title)
-                .add("subMinistryCode", subMinistryCode)
-                .add("subMinistryDescr", subMinistryDescr)
-                .add("emailAddress", emailAddress)
-                .add("phoneNumber", phoneNumber)
-                .add("authentication", authentication)
-                .add("address", address)
-                .add("birthYear", birthYear)
-                .add("birthDate", birthDate)
-                .add("countryOfResidence", countryOfResidence)
-                .add("employmentCountry", employmentCountry)
-                .add("language", language)
-                .add("jobStatus", jobStatus)
-                .add("deptCode", deptCode)
-                .add("deptDescr", deptDescr)
-                .add("jobCode", jobCode)
-                .add("jobDescr", jobDescr)
-                .add("supervisorEmplid", supervisorEmplid)
-                .add("clientUpdatedAt", clientUpdatedAt)
-                .add("clientIntegrationId", clientIntegrationId)
-                .toString();
+        return new StringBuilder("Person{")
+            .append("id='").append(id).append('\'')
+            .append(", accountNumber='").append(accountNumber).append('\'')
+            .append(", activeStatus='").append(activeStatus).append('\'')
+            .append(", birthDay=").append(birthDay)
+            .append(", birthMonth=").append(birthMonth)
+            .append(", cruEmployee=").append(cruEmployee)
+            .append(", dateJoinedStaff='").append(dateJoinedStaff).append('\'')
+            .append(", firstName='").append(firstName).append('\'')
+            .append(", fundingSource='").append(fundingSource).append('\'')
+            .append(", gender='").append(gender).append('\'')
+            .append(", hrStatusCode='").append(hrStatusCode).append('\'')
+            .append(", isStaff=").append(isStaff)
+            .append(", lakeHartMailCode='").append(lakeHartMailCode).append('\'')
+            .append(", lastName='").append(lastName).append('\'')
+            .append(", locationCode='").append(locationCode).append('\'')
+            .append(", locationWork='").append(locationWork).append('\'')
+            .append(", maritalStatus='").append(maritalStatus).append('\'')
+            .append(", middleName='").append(middleName).append('\'')
+            .append(", nameAddressEditFlag='").append(nameAddressEditFlag).append('\'')
+            .append(", originalHireDate='").append(originalHireDate).append('\'')
+            .append(", paygroup='").append(paygroup).append('\'')
+            .append(", preferredName='").append(preferredName).append('\'')
+            .append(", ministryCode='").append(ministryCode).append('\'')
+            .append(", ministryDescr='").append(ministryDescr).append('\'')
+            .append(", suffix='").append(suffix).append('\'')
+            .append(", title='").append(title).append('\'')
+            .append(", subMinistryCode='").append(subMinistryCode).append('\'')
+            .append(", subMinistryDescr='").append(subMinistryDescr).append('\'')
+            .append(", emailAddress=").append(emailAddress)
+            .append(", phoneNumber=").append(phoneNumber)
+            .append(", authentication=").append(authentication)
+            .append(", address=").append(address)
+            .append(", birthYear=").append(birthYear)
+            .append(", birthDate='").append(birthDate).append('\'')
+            .append(", countryOfResidence='").append(countryOfResidence).append('\'')
+            .append(", employmentCountry='").append(employmentCountry).append('\'')
+            .append(", language='").append(language).append('\'')
+            .append(", jobStatus='").append(jobStatus).append('\'')
+            .append(", deptCode='").append(deptCode).append('\'')
+            .append(", deptDescr='").append(deptDescr).append('\'')
+            .append(", jobCode='").append(jobCode).append('\'')
+            .append(", jobDescr='").append(jobDescr).append('\'')
+            .append(", supervisorEmplid='").append(supervisorEmplid).append('\'')
+            .append(", clientUpdatedAt='").append(clientUpdatedAt).append('\'')
+            .append(", clientIntegrationId='").append(clientIntegrationId).append('\'')
+            .append('}').toString();
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Person)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         Person person = (Person) o;
-        return Objects.equal(id, person.id) &&
-                Objects.equal(accountNumber, person.accountNumber) &&
-                Objects.equal(activeStatus, person.activeStatus) &&
-                Objects.equal(birthDay, person.birthDay) &&
-                Objects.equal(birthMonth, person.birthMonth) &&
-                Objects.equal(cruEmployee, person.cruEmployee) &&
-                Objects.equal(dateJoinedStaff, person.dateJoinedStaff) &&
-                Objects.equal(firstName, person.firstName) &&
-                Objects.equal(fundingSource, person.fundingSource) &&
-                Objects.equal(gender, person.gender) &&
-                Objects.equal(hrStatusCode, person.hrStatusCode) &&
-                Objects.equal(isStaff, person.isStaff) &&
-                Objects.equal(lakeHartMailCode, person.lakeHartMailCode) &&
-                Objects.equal(lastName, person.lastName) &&
-                Objects.equal(locationCode, person.locationCode) &&
-                Objects.equal(locationWork, person.locationWork) &&
-                Objects.equal(maritalStatus, person.maritalStatus) &&
-                Objects.equal(middleName, person.middleName) &&
-                Objects.equal(nameAddressEditFlag, person.nameAddressEditFlag) &&
-                Objects.equal(originalHireDate, person.originalHireDate) &&
-                Objects.equal(paygroup, person.paygroup) &&
-                Objects.equal(preferredName, person.preferredName) &&
-                Objects.equal(ministryCode, person.ministryCode) &&
-                Objects.equal(ministryDescr, person.ministryDescr) &&
-                Objects.equal(suffix, person.suffix) &&
-                Objects.equal(title, person.title) &&
-                Objects.equal(subMinistryCode, person.subMinistryCode) &&
-                Objects.equal(subMinistryDescr, person.subMinistryDescr) &&
-                Objects.equal(emailAddress, person.emailAddress) &&
-                Objects.equal(phoneNumber, person.phoneNumber) &&
-                Objects.equal(authentication, person.authentication) &&
-                Objects.equal(address, person.address) &&
-                Objects.equal(birthYear, person.birthYear) &&
-                Objects.equal(birthDate, person.birthDate) &&
-                Objects.equal(countryOfResidence, person.countryOfResidence) &&
-                Objects.equal(employmentCountry, person.employmentCountry) &&
-                Objects.equal(language, person.language) &&
-                Objects.equal(jobStatus, person.jobStatus) &&
-                Objects.equal(deptCode, person.deptCode) &&
-                Objects.equal(deptDescr, person.deptDescr) &&
-                Objects.equal(jobCode, person.jobCode) &&
-                Objects.equal(jobDescr, person.jobDescr) &&
-                Objects.equal(supervisorEmplid, person.supervisorEmplid) &&
-                Objects.equal(clientUpdatedAt, person.clientUpdatedAt) &&
-                Objects.equal(clientIntegrationId, person.clientIntegrationId);
+        return Objects.equals(id, person.id) &&
+                Objects.equals(accountNumber, person.accountNumber) &&
+                Objects.equals(activeStatus, person.activeStatus) &&
+                Objects.equals(birthDay, person.birthDay) &&
+                Objects.equals(birthMonth, person.birthMonth) &&
+                Objects.equals(cruEmployee, person.cruEmployee) &&
+                Objects.equals(dateJoinedStaff, person.dateJoinedStaff) &&
+                Objects.equals(firstName, person.firstName) &&
+                Objects.equals(fundingSource, person.fundingSource) &&
+                Objects.equals(gender, person.gender) &&
+                Objects.equals(hrStatusCode, person.hrStatusCode) &&
+                Objects.equals(isStaff, person.isStaff) &&
+                Objects.equals(lakeHartMailCode, person.lakeHartMailCode) &&
+                Objects.equals(lastName, person.lastName) &&
+                Objects.equals(locationCode, person.locationCode) &&
+                Objects.equals(locationWork, person.locationWork) &&
+                Objects.equals(maritalStatus, person.maritalStatus) &&
+                Objects.equals(middleName, person.middleName) &&
+                Objects.equals(nameAddressEditFlag, person.nameAddressEditFlag) &&
+                Objects.equals(originalHireDate, person.originalHireDate) &&
+                Objects.equals(paygroup, person.paygroup) &&
+                Objects.equals(preferredName, person.preferredName) &&
+                Objects.equals(ministryCode, person.ministryCode) &&
+                Objects.equals(ministryDescr, person.ministryDescr) &&
+                Objects.equals(suffix, person.suffix) &&
+                Objects.equals(title, person.title) &&
+                Objects.equals(subMinistryCode, person.subMinistryCode) &&
+                Objects.equals(subMinistryDescr, person.subMinistryDescr) &&
+                Objects.equals(emailAddress, person.emailAddress) &&
+                Objects.equals(phoneNumber, person.phoneNumber) &&
+                Objects.equals(authentication, person.authentication) &&
+                Objects.equals(address, person.address) &&
+                Objects.equals(birthYear, person.birthYear) &&
+                Objects.equals(birthDate, person.birthDate) &&
+                Objects.equals(countryOfResidence, person.countryOfResidence) &&
+                Objects.equals(employmentCountry, person.employmentCountry) &&
+                Objects.equals(language, person.language) &&
+                Objects.equals(jobStatus, person.jobStatus) &&
+                Objects.equals(deptCode, person.deptCode) &&
+                Objects.equals(deptDescr, person.deptDescr) &&
+                Objects.equals(jobCode, person.jobCode) &&
+                Objects.equals(jobDescr, person.jobDescr) &&
+                Objects.equals(supervisorEmplid, person.supervisorEmplid) &&
+                Objects.equals(clientUpdatedAt, person.clientUpdatedAt) &&
+                Objects.equals(clientIntegrationId, person.clientIntegrationId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id, accountNumber, activeStatus, birthDay, birthMonth, cruEmployee, dateJoinedStaff, firstName, fundingSource, gender, hrStatusCode, isStaff, lakeHartMailCode, lastName, locationCode, locationWork, maritalStatus, middleName, nameAddressEditFlag, originalHireDate, paygroup, preferredName, ministryCode, ministryDescr, suffix, title, subMinistryCode, subMinistryDescr, emailAddress, phoneNumber, authentication, address, birthYear, birthDate, countryOfResidence, employmentCountry, language, jobStatus, deptCode, deptDescr, jobCode, jobDescr, supervisorEmplid, clientUpdatedAt, clientIntegrationId);
+        return Objects.hash(id, accountNumber, activeStatus, birthDay, birthMonth, cruEmployee, dateJoinedStaff, firstName, fundingSource, gender, hrStatusCode, isStaff, lakeHartMailCode, lastName, locationCode, locationWork, maritalStatus, middleName, nameAddressEditFlag, originalHireDate, paygroup, preferredName, ministryCode, ministryDescr, suffix, title, subMinistryCode, subMinistryDescr, emailAddress, phoneNumber, authentication, address, birthYear, birthDate, countryOfResidence, employmentCountry, language, jobStatus, deptCode, deptDescr, jobCode, jobDescr, supervisorEmplid, clientUpdatedAt, clientIntegrationId);
     }
 }

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/PhoneNumber.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/PhoneNumber.java
@@ -34,13 +34,13 @@ public class PhoneNumber {
 
     /**
      * No args constructor for use in serialization
-     * 
+     *
      */
     public PhoneNumber() {
     }
 
     /**
-     * 
+     *
      * @param clientIntegrationId
      * @param number
      * @param location
@@ -58,7 +58,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @return
      *     The id
      */
@@ -68,7 +68,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @param id
      *     The id
      */
@@ -78,7 +78,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @return
      *     The primary
      */
@@ -88,7 +88,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @param primary
      *     The primary
      */
@@ -98,7 +98,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @return
      *     The location
      */
@@ -108,7 +108,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @param location
      *     The location
      */
@@ -118,7 +118,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @return
      *     The number
      */
@@ -128,7 +128,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @param number
      *     The number
      */
@@ -138,7 +138,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @return
      *     The parentId
      */
@@ -148,7 +148,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @param parentId
      *     The parent_id
      */
@@ -158,7 +158,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @return
      *     The clientIntegrationId
      */
@@ -168,7 +168,7 @@ public class PhoneNumber {
     }
 
     /**
-     * 
+     *
      * @param clientIntegrationId
      *     The client_integration_id
      */

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/PhoneNumber.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/PhoneNumber.java
@@ -1,7 +1,7 @@
 
 package org.ccci.gto.globalreg.entity.jackson;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/PhoneNumber.java
+++ b/entities/jackson/src/main/java/org/ccci/gto/globalreg/entity/jackson/PhoneNumber.java
@@ -5,8 +5,7 @@ import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
@@ -180,31 +179,31 @@ public class PhoneNumber {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("id", id)
-                .add("primary", primary)
-                .add("location", location)
-                .add("number", number)
-                .add("parentId", parentId)
-                .add("clientIntegrationId", clientIntegrationId)
-                .toString();
+        return new StringBuilder("PhoneNumber{")
+            .append("id='").append(id).append('\'')
+            .append(", primary=").append(primary)
+            .append(", location='").append(location).append('\'')
+            .append(", number='").append(number).append('\'')
+            .append(", parentId='").append(parentId).append('\'')
+            .append(", clientIntegrationId='").append(clientIntegrationId).append('\'')
+            .append('}').toString();
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PhoneNumber)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         PhoneNumber that = (PhoneNumber) o;
-        return Objects.equal(id, that.id) &&
-                Objects.equal(primary, that.primary) &&
-                Objects.equal(location, that.location) &&
-                Objects.equal(number, that.number) &&
-                Objects.equal(parentId, that.parentId) &&
-                Objects.equal(clientIntegrationId, that.clientIntegrationId);
+        return Objects.equals(id, that.id) &&
+                Objects.equals(primary, that.primary) &&
+                Objects.equals(location, that.location) &&
+                Objects.equals(number, that.number) &&
+                Objects.equals(parentId, that.parentId) &&
+                Objects.equals(clientIntegrationId, that.clientIntegrationId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id, primary, location, number, parentId, clientIntegrationId);
+        return Objects.hash(id, primary, location, number, parentId, clientIntegrationId);
     }
 }

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-httpclient</artifactId>

--- a/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
+++ b/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
@@ -1,7 +1,6 @@
 package org.ccci.gto.globalreg.httpclient;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.net.HttpHeaders;
 import org.apache.http.HttpEntity;
@@ -27,11 +26,13 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class HttpClientGlobalRegistryClient extends BaseGlobalRegistryClient {
-    private final static Joiner JOINER_PATH = Joiner.on("/").skipNulls();
 
     private final static ResponseHandler<Response> RESPONSE_HANDLER = new ResponseHandler<Response>() {
         @Nonnull
@@ -103,7 +104,10 @@ public class HttpClientGlobalRegistryClient extends BaseGlobalRegistryClient {
         // build the request uri
         final URIBuilder builder = new URIBuilder(this.apiUrl);
         final String path = builder.getPath();
-        builder.setPath(path + JOINER_PATH.join(request.path));
+        String pathSegments = Arrays.stream(request.path)
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining("/"));
+        builder.setPath(path + pathSegments);
         for (final Map.Entry<String, List<String>> param : request.queryParams.entrySet()) {
             for (String value : param.getValue()) {
                 builder.addParameter(param.getKey(), value);

--- a/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
+++ b/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
@@ -1,6 +1,5 @@
 package org.ccci.gto.globalreg.httpclient;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.net.HttpHeaders;
 import org.apache.http.HttpEntity;
@@ -26,6 +25,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +88,7 @@ public class HttpClientGlobalRegistryClient extends BaseGlobalRegistryClient {
             // send content when necessary
             if (request.content != null && req instanceof HttpEntityEnclosingRequest) {
                 ((HttpEntityEnclosingRequest) req).setEntity(new StringEntity(request.content,
-                        ContentType.create(request.contentType, Charsets.UTF_8)));
+                        ContentType.create(request.contentType, StandardCharsets.UTF_8)));
             }
 
             // execute request & return response

--- a/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
+++ b/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
@@ -1,7 +1,6 @@
 package org.ccci.gto.globalreg.httpclient;
 
 import com.google.common.base.Throwables;
-import com.google.common.net.HttpHeaders;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpResponse;
@@ -72,7 +71,7 @@ public class HttpClientGlobalRegistryClient extends BaseGlobalRegistryClient {
             if (req == null) {
                 throw new IllegalArgumentException("Request specifies unsupported method: " + request.method);
             }
-            req.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + this.accessToken);
+            req.addHeader("Authorization", "Bearer " + this.accessToken);
             for (final Map.Entry<String, String> header : request.headers.entrySet()) {
                 req.addHeader(header.getKey(), header.getValue());
             }

--- a/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
+++ b/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
@@ -1,6 +1,5 @@
 package org.ccci.gto.globalreg.httpclient;
 
-import com.google.common.base.Throwables;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpResponse;
@@ -95,7 +94,7 @@ public class HttpClientGlobalRegistryClient extends BaseGlobalRegistryClient {
                 return client.execute(req, RESPONSE_HANDLER);
             }
         } catch (final IOException | URISyntaxException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
+++ b/httpclient/src/main/java/org/ccci/gto/globalreg/httpclient/HttpClientGlobalRegistryClient.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Map;
 
 public class HttpClientGlobalRegistryClient extends BaseGlobalRegistryClient {
@@ -103,8 +104,10 @@ public class HttpClientGlobalRegistryClient extends BaseGlobalRegistryClient {
         final URIBuilder builder = new URIBuilder(this.apiUrl);
         final String path = builder.getPath();
         builder.setPath(path + JOINER_PATH.join(request.path));
-        for (final Map.Entry<String, String> param : request.queryParams.entries()) {
-            builder.addParameter(param.getKey(), param.getValue());
+        for (final Map.Entry<String, List<String>> param : request.queryParams.entrySet()) {
+            for (String value : param.getValue()) {
+                builder.addParameter(param.getKey(), value);
+            }
         }
         return builder.build();
     }

--- a/jaxrs10/pom.xml
+++ b/jaxrs10/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-jaxrs10</artifactId>

--- a/jaxrs10/src/main/java/org/ccci/gto/globalreg/jaxrs/JaxrsGlobalRegistryClient.java
+++ b/jaxrs10/src/main/java/org/ccci/gto/globalreg/jaxrs/JaxrsGlobalRegistryClient.java
@@ -2,7 +2,6 @@ package org.ccci.gto.globalreg.jaxrs;
 
 import com.google.common.base.Throwables;
 import com.google.common.io.CharStreams;
-import com.google.common.net.HttpHeaders;
 import org.ccci.gto.globalreg.BaseGlobalRegistryClient;
 import org.ccci.gto.globalreg.UnauthorizedException;
 import org.slf4j.Logger;
@@ -44,14 +43,14 @@ public class JaxrsGlobalRegistryClient extends BaseGlobalRegistryClient {
             conn.setConnectTimeout(connectTimeout);
             conn.setReadTimeout(readTimeout);
             conn.setRequestMethod(request.method);
-            conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "Bearer " + this.accessToken);
+            conn.setRequestProperty("Authorization", "Bearer " + this.accessToken);
             for (final Map.Entry<String, String> header : request.headers.entrySet()) {
                 conn.setRequestProperty(header.getKey(), header.getValue());
             }
 
             // send content when necessary
             if (request.content != null) {
-                conn.setRequestProperty(HttpHeaders.CONTENT_TYPE, request.contentType);
+                conn.setRequestProperty("Content-Type", request.contentType);
                 conn.setDoOutput(true);
                 try (OutputStream raw = conn.getOutputStream(); OutputStreamWriter out = new OutputStreamWriter(raw)) {
                     out.write(request.content);

--- a/jaxrs10/src/main/java/org/ccci/gto/globalreg/jaxrs/JaxrsGlobalRegistryClient.java
+++ b/jaxrs10/src/main/java/org/ccci/gto/globalreg/jaxrs/JaxrsGlobalRegistryClient.java
@@ -1,6 +1,5 @@
 package org.ccci.gto.globalreg.jaxrs;
 
-import com.google.common.base.Throwables;
 import org.ccci.gto.globalreg.BaseGlobalRegistryClient;
 import org.ccci.gto.globalreg.UnauthorizedException;
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ public class JaxrsGlobalRegistryClient extends BaseGlobalRegistryClient {
                     out.write(request.content);
                 } catch (final IOException e) {
                     LOG.debug("error writing data to connection", e);
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
 
@@ -80,7 +79,7 @@ public class JaxrsGlobalRegistryClient extends BaseGlobalRegistryClient {
             }
         } catch (final IOException e) {
             LOG.debug("error processing request: {}", uri, e);
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         } finally {
             if (conn != null) {
                 conn.disconnect();

--- a/jaxrs10/src/main/java/org/ccci/gto/globalreg/jaxrs/JaxrsGlobalRegistryClient.java
+++ b/jaxrs10/src/main/java/org/ccci/gto/globalreg/jaxrs/JaxrsGlobalRegistryClient.java
@@ -1,7 +1,6 @@
 package org.ccci.gto.globalreg.jaxrs;
 
 import com.google.common.base.Throwables;
-import com.google.common.io.CharStreams;
 import org.ccci.gto.globalreg.BaseGlobalRegistryClient;
 import org.ccci.gto.globalreg.UnauthorizedException;
 import org.slf4j.Logger;
@@ -14,6 +13,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Collection;
@@ -63,13 +63,17 @@ public class JaxrsGlobalRegistryClient extends BaseGlobalRegistryClient {
             // read & return response
             final int code = conn.getResponseCode();
             try (InputStream raw = conn.getInputStream(); InputStreamReader in = new InputStreamReader(raw)) {
-                return new Response(conn.getResponseCode(), CharStreams.toString(in));
+                StringWriter writer = new StringWriter();
+                in.transferTo(writer);
+                return new Response(conn.getResponseCode(), writer.toString());
             } catch (final IOException e) {
                 try (
                     InputStream rawError = conn.getErrorStream();
                     InputStreamReader errorReader = new InputStreamReader(rawError)
                 ) {
-                    return new Response(conn.getResponseCode(), CharStreams.toString(errorReader));
+                    StringWriter writer = new StringWriter();
+                    errorReader.transferTo(writer);
+                    return new Response(conn.getResponseCode(), writer.toString());
                 } catch (final IOException e2) {
                     return new Response(code, "<error content not available>");
                 }

--- a/jaxrs20/pom.xml
+++ b/jaxrs20/pom.xml
@@ -29,6 +29,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.ccci.gto</groupId>

--- a/jaxrs20/pom.xml
+++ b/jaxrs20/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-jaxrs20</artifactId>

--- a/jaxrs20/src/main/java/org/ccci/gto/globalreg/jaxrs20/Jaxrs20GlobalRegistryClient.java
+++ b/jaxrs20/src/main/java/org/ccci/gto/globalreg/jaxrs20/Jaxrs20GlobalRegistryClient.java
@@ -10,6 +10,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -82,9 +83,11 @@ public class Jaxrs20GlobalRegistryClient extends BaseGlobalRegistryClient
 
     private WebTarget addQueryParameters(Request request, WebTarget webTarget)
     {
-        for(Map.Entry<String, String> entry : request.queryParams.entries())
+        for(Map.Entry<String, List<String>> entry : request.queryParams.entrySet())
         {
-            webTarget = webTarget.queryParam(entry.getKey(), entry.getValue());
+            for (String value : entry.getValue()) {
+                webTarget = webTarget.queryParam(entry.getKey(), value);
+            }
         }
         return webTarget;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>18.0</version>
-      </dependency>
-
-      <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>2.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.ccci.gto</groupId>
   <artifactId>global-registry-client</artifactId>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>0.3.2</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
   </distributionManagement>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -45,6 +45,7 @@
     <httpclient.version>4.3.6</httpclient.version>
     <httpcore.version>4.3.2</httpcore.version>
     <jackson.version>2.9.9</jackson.version>
+    <jaxb.version>2.3.1</jaxb.version>
   </properties>
 
   <dependencyManagement>
@@ -110,6 +111,12 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxb.version}</version>
       </dependency>
 
 

--- a/serializer-jackson/pom.xml
+++ b/serializer-jackson/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-serializer-jackson</artifactId>

--- a/serializer-jackson/src/main/java/org/ccci/gto/globalreg/serializer/jackson/JacksonSerializer.java
+++ b/serializer-jackson/src/main/java/org/ccci/gto/globalreg/serializer/jackson/JacksonSerializer.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Throwables;
 import org.ccci.gto.globalreg.Type;
 import org.ccci.gto.globalreg.serializer.JsonIntermediateSerializer;
 import org.ccci.gto.globalreg.serializer.SerializerException;
@@ -46,7 +45,7 @@ public class JacksonSerializer extends JsonIntermediateSerializer<JsonNode, Json
             throw new UnparsableJsonException(e);
         } catch (final IOException e) {
             LOG.debug("Unexpected IOException", e);
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -60,7 +59,7 @@ public class JacksonSerializer extends JsonIntermediateSerializer<JsonNode, Json
         catch(IOException exception)
         {
             LOG.error("Error writing JsonNode to String", exception);
-            throw Throwables.propagate(exception);
+            throw new RuntimeException(exception);
         }
     }
 

--- a/serializer-json/pom.xml
+++ b/serializer-json/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-serializer-json</artifactId>

--- a/serializer-jsonpath/pom.xml
+++ b/serializer-jsonpath/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>global-registry-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>global-registry-client-serializer-jsonpath</artifactId>


### PR DESCRIPTION
This library is a dependency of both `giveaem` and `aem-authentication`, which are being hosted on AEM. AEM is dropping Guava from its provided libraries at the end of August, so I wanted to make a version of this library that works without Guava. I also decided to upgrade this version to Java 11 to make for some nicer APIs to replace Guava with, and get a bit closer to the current times. Java 11 is what our AEM instances are running as well.